### PR TITLE
Update `resolveExpression()`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <name>Selenium Scripter</name>
     <groupId>com.kytheralabs</groupId>
     <artifactId>seleniumscripter</artifactId>
-    <version>1.7.6</version>
+    <version>1.7.7-SNAPSHOT</version>
 
     <!-- Project Properties -->
     <properties>

--- a/src/main/java/com/kytheralabs/SeleniumScripter.java
+++ b/src/main/java/com/kytheralabs/SeleniumScripter.java
@@ -207,13 +207,7 @@ public class SeleniumScripter {
     private String resolveExpressionValue(String expression) throws ParseException {
         String resolved = String.valueOf(expression); // Create a deep copy of the expression
 
-        // If the brackets indicators `{}` are not in the expression, then just return the literal value
-        if (expression.matches("\\{[a-zA-Z_][a-zA-Z_0-9]*}") == false) {
-            System.err.println("Contains no expressions!");
-            return expression;
-        }
-
-        // Create the regex pattern and matcher itterable
+        // Create the regex pattern and matcher iterable
         Pattern identifierPattern = Pattern.compile("\\{[a-zA-Z_][a-zA-Z_0-9]*}");
         Matcher matches = identifierPattern.matcher(resolved);
 


### PR DESCRIPTION
This is a patch that removes the logical short circuit in `resolveExpression()` that was incorrectly exiting early when finding any match with regex.

***

@pankaj-tripat and I sat down and reviewed the behavior of this function to diagnose the incorrect short circuiting that was occurring last week. Turns out the fact that there was not an `== false` was a bug, but it was a bug that was preventing another bug, where the `match()` method would return a non-null iterable and continue with variable replacement anyways, in spite of no `{}` existing in the expression.

All of that was unnecessary anyhow because the while-loop also logically does the same as the `if` statement's intended behavior.
